### PR TITLE
Updated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ The associated paper titled *MirChecker: Detecting Bugs in Rust Programs via Sta
 2. Build & Install
 
     ```sh
+    # make sure to have llvm/clang version 15 installed
+    $ export LIBCLANG_PATH=`llvm-config-15 --libdir`/libclang.so.1
     # You can build and install the cargo subcommand:
-    $ cargo install --path .
+    $ cargo install --locked --path .
     
     # Or, you can only build the checker itself:
     $ cargo build
     ```
+
+Note: clang 15 is required because of [this issue with handling anonymous structs in clang 16](https://github.com/rust-lang/rust-bindgen/issues/2312).
 
 ## Example
 


### PR DESCRIPTION
* require `--locked` with `cargo install` to avoid updating dependencies to versions unsupported with the required rust toolchain version. Probably the reason for issues #11 and #12.
* added note that llvm 15 is required due to a bug in libclang version 16 that breaks handling of anonymous structs.